### PR TITLE
add release notes support on android

### DIFF
--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -24,11 +24,12 @@ export const getAndroidVersion = async (bundleId, country) => {
 
   const text = await res.text();
   const version = text.match(/\[\[\[['"]((\d+\.)+\d+)['"]\]\],/)[1];
+  const notes = text.match(/<div itemprop="description">(.*?)<\/div>/)[1];
 
   return {
     version: version || null,
     releasedAt: (new Date()).toISOString(),
-    notes: "",
+    notes: notes || "",
     url: `https://play.google.com/store/apps/details?id=${bundleId}&hl=${country}`,
     lastChecked: (new Date()).toISOString()
   };

--- a/src/providers/android.js
+++ b/src/providers/android.js
@@ -24,7 +24,7 @@ export const getAndroidVersion = async (bundleId, country) => {
 
   const text = await res.text();
   const version = text.match(/\[\[\[['"]((\d+\.)+\d+)['"]\]\],/)[1];
-  const notes = text.match(/<div itemprop="description">(.*?)<\/div>/)[1];
+  const notes = text.match(/<div itemprop="description">(.*?)<\/div>/)?.[1];
 
   return {
     version: version || null,


### PR DESCRIPTION
Hello,

I have found the way to support release notes on android using regex.

Let me know what do you think about that solution:

```
  const text = await res.text();
  const version = text.match(/\[\[\[['"]((\d+\.)+\d+)['"]\]\],/)[1];
  const notes = text.match(/<div itemprop="description">(.*?)<\/div>/)[1];

  return {
    version: version || null,
    releasedAt: (new Date()).toISOString(),
    notes: notes || "",
    url: `https://play.google.com/store/apps/details?id=${bundleId}&hl=${country}`,
    lastChecked: (new Date()).toISOString()
  };
```